### PR TITLE
Support configurable schema format

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@ require 'sql_migration_helper'
 require 'standalone_migrations'
 
 StandaloneMigrations::Tasks.load_tasks
+
+ActiveRecord::Base.schema_format = ENV['SCHEMA_FORMAT']&.to_sym || :ruby


### PR DESCRIPTION
In lieu of specs:

```rb
2.5.1 (main):0 > ENV['SCHEMA_FORMAT']&.to_sym || :ruby
:ruby
2.5.1 (main):0 > ENV['SCHEMA_FORMAT'] = 'sql'
"sql"
2.5.1 (main):0 > ENV['SCHEMA_FORMAT']&.to_sym || :ruby
:sql
```